### PR TITLE
Fix: Bypass error with Packr2 index path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-buildk:
+buildcerberus:
 	GO111MODULE=on go build -ldflags="-s -w" -o bin/cerberus ./main.go
 
-install: buildk
+buildfront:
+	(cd ./web && yarn install && yarn build)
+
+install: buildcerberus buildfront
 	sudo cp bin/cerberus /usr/local/bin

--- a/administration/server.go
+++ b/administration/server.go
@@ -20,7 +20,7 @@ func StartServer(ctx context.Context, group *sync.WaitGroup) {
 
 	// Generate administration frontend fileserver.
 	frontApplicationBox := packr.New("frontApplication", "../web/dist")
-	frontAppServer := spaHandler{indexPath: "index.html", staticPath: frontApplicationBox.Path}
+	frontAppServer := spaHandler{indexPath: "index.html", box: frontApplicationBox}
 
 	// Catch interrupt signal in channel.
 	interruptSignalChannel := make(chan os.Signal, 1)


### PR DESCRIPTION
# PR Details

An error happening on Packr2 makes a redirection loop when you try to call the index file.

[Explanation here](https://github.com/gobuffalo/packr/issues/198)

## Description

This PR fixes this issue by using conditions on frontend routes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
